### PR TITLE
Add an owner to the token contract

### DIFF
--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -27,8 +27,7 @@ contract Token is
     error UnauthorizedFrom(address token, address user);
     error UnauthorizedTo(address token, address user);
 
-    address private m_owner;
-    uint8   private m_decimals;
+    uint8 private m_decimals;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(IAuthority _authority) PermissionManaged(_authority) {


### PR DESCRIPTION
In order to support things such as https://github.com/Uniswap/v4-core/issues/326, we need an owner.

Note that by default the owner is address(0). Owner can be set (or reset at any point) by an authorized account. So the PermissionManager remains in full control.